### PR TITLE
Global templates

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -246,7 +246,7 @@ fn test_take_named() -> Result<(), Box<dyn Error>> {
 #[serial]
 fn test_take_from_template() -> Result<(), Box<dyn Error>> {
     let templ_content = "Template";
-    let other_content = "Template";
+    let other_content = "Other template";
     let _t = Test::init(
         "take_from_template",
         vec![],

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -100,6 +100,32 @@ fn test_new_name_from_stdin() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[serial]
+fn test_new_global() -> Result<(), Box<dyn Error>> {
+    let home_dir = Path::new("home");
+    let config_dir = home_dir.join(".config").join("templaar");
+    let _t = Test::init(
+        "new_global",
+        vec![config_dir.to_path_buf()],
+        HashMap::new(),
+        "touch",
+    );
+    env::set_var("HOME", env::current_dir()?.join(home_dir));
+
+    let mut cmd = Command::cargo_bin("templaar")?;
+    cmd.arg("new").arg("--global");
+    cmd.assert().success();
+
+    let templ_path = config_dir.join("templ.aar");
+    assert!(templ_path.exists());
+    for path in fs::read_dir(env::current_dir()?)? {
+        assert!(path?.path().is_dir());
+    }
+
+    Ok(())
+}
+
+#[test]
+#[serial]
 fn test_new_exists() -> Result<(), Box<dyn Error>> {
     let _t = Test::init(
         "new_exists",


### PR DESCRIPTION
Adds support for "global templates" stored in `~/.config/templaar/`. The templates can be created using `templaar new --global` and will be used by `templaar take` if no suitable template is found in the current or parent directories. When using global templates, the `templaar take` command must always specify the template name using the `-t` option.

Also fixes small error in one of the existing tests.