### PR TITLE
Warn when the taken file is the same as template

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -220,7 +220,20 @@ fn take(name: &Option<String>, template: &Option<String>) -> Result<(), Box<dyn 
     fs::File::create(&file)?.write_all(templ.as_bytes())?;
 
     let editor = env::var("EDITOR")?;
-    process::Command::new(editor).arg(file).status()?;
+    process::Command::new(editor).arg(&file).status()?;
+
+    let mut file_contents = String::new();
+    fs::File::open(&file)?.read_to_string(&mut file_contents)?;
+    if file_contents == templ {
+        let mut buf = String::new();
+        print!("The file contains no change from the template. Save it anyways? [Y/n]: ");
+        io::stdout().flush()?;
+        io::stdin().read_line(&mut buf)?;
+
+        if buf.trim().to_lowercase() == "n" {
+            std::fs::remove_file(file)?;
+        }
+    }
 
     Ok(())
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -331,6 +331,27 @@ fn test_take_global_precedence() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[serial]
+fn test_take_no_change() -> Result<(), Box<dyn Error>> {
+    let templ_content = "Template";
+    let _t = Test::init(
+        "take_no_change",
+        vec![],
+        HashMap::from([(PathBuf::from_str(".templ.aar")?, templ_content.to_string())]),
+        "touch",
+    );
+
+    let mut cmd = Command::cargo_bin("templaar")?;
+    cmd.arg("take").write_stdin("n");
+    cmd.assert().success();
+
+    let file_path = Path::new("templ");
+    assert!(!file_path.exists());
+
+    Ok(())
+}
+
+#[test]
+#[serial]
 fn test_take_exists() -> Result<(), Box<dyn Error>> {
     let _t = Test::init(
         "take_exists",


### PR DESCRIPTION
After running `templaar take`, if the created file doesn't contain any change from the template, warn the user and allow him not to save the file (by default the file is saved).