### PR TITLE
Introduce directory templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,18 @@
 Templaar is a simple tool for Linux for creating text files from templates.
 
 Usage is based on two commands:
-- `templaar new` - creates a new template file
-- `templaar take` - finds a template file and creates a new file from it
+- `templaar new` - creates a new template
+- `templaar take` - finds a template and creates new file(s) from it
 
-Both commands open the created file in the default system editor (taken from
-`$EDITOR` env var).
+Both commands open the created file(s) in the default system editor (taken from
+the `$EDITOR` env var) for further editing.
 
-Templates are stored as hidden files named `.<TEMPL>.aar`. When searching for
-templates, Templaar starts from the current directory and recursively proceeds
-to its parent directories, until a template is found.
+There are two kinds of templates: *file* templates consisting of a single file
+and *directory* templates consisting of a directory containing multiple files.
+
+Templates are stored as hidden files/directories named `.<TEMPL>.aar`. When
+searching for templates, Templaar starts from the current directory and
+recursively proceeds to its parent directories, until a template is found.
 
 It is also possible to create a global template in `~/.config/templaar/`. This
 is done using the `--global` option of the `new` command and global templates
@@ -26,14 +29,17 @@ Arguments:
   [NAME]  Name of the template
 
 Options:
-  -g, --global  Make the template global
-  -h, --help    Print help
+  -g, --global              Make the template global
+  -f, --files [<FILES>...]  Create the template from file(s).
+                            In case of multiple files, the template will be a directory.
+  -h, --help                Print help
 ```
 ```
 Usage: templaar take [OPTIONS] [NAME]
 
 Arguments:
-  [NAME]  Name of the created file
+  [NAME]  Name of the created file.
+          Path in the case of a directory template.
 
 Options:
   -t, --template <TEMPLATE>  Use specific template

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,17 +54,34 @@ impl fmt::Display for NoTemplateFound {
 }
 
 #[derive(Debug, Clone)]
-struct FileExists {
+struct TemplExists {
     path: PathBuf,
 }
 
-impl error::Error for FileExists {}
+impl error::Error for TemplExists {}
 
-impl fmt::Display for FileExists {
+impl fmt::Display for TemplExists {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "File {} already exists. Please edit it manually.",
+            "Template {} already exists. Please edit it manually.",
+            self.path.to_str().ok_or(fmt::Error)?
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PathExists {
+    path: PathBuf,
+}
+
+impl error::Error for PathExists {}
+
+impl fmt::Display for PathExists {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Cannot create {} from template, path already exists.",
             self.path.to_str().ok_or(fmt::Error)?
         )
     }
@@ -140,7 +157,7 @@ fn new(name: &Option<String>, global: bool) -> Result<(), Box<dyn error::Error>>
     let templ_file = templ_dir.join(templ_to_path(&templ_name, global));
 
     if templ_file.exists() {
-        return Err(Box::new(FileExists { path: templ_file }));
+        return Err(Box::new(TemplExists { path: templ_file }));
     }
 
     let editor = env::var("EDITOR")?;
@@ -213,7 +230,7 @@ fn take(name: &Option<String>, template: &Option<String>) -> Result<(), Box<dyn 
     let file = env::current_dir()?.join(filename);
 
     if file.exists() {
-        return Err(Box::new(FileExists { path: file }));
+        return Err(Box::new(PathExists { path: file }));
     }
 
     // Write template contents to file and open it in EDITOR

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -143,6 +143,42 @@ fn test_new_exists() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[serial]
+fn test_new_from_file() -> Result<(), Box<dyn Error>> {
+    let templ_content = "Template";
+    let _t = Test::init(
+        "new_from_file",
+        vec![],
+        HashMap::from([(PathBuf::from_str("templ")?, templ_content.to_string())]),
+        "touch",
+    );
+
+    let mut cmd = Command::cargo_bin("templaar")?;
+    cmd.arg("new").arg("-f").arg("templ").arg("templ");
+    cmd.assert().success();
+
+    let templ_path = Path::new(".templ.aar");
+    let mut contents = String::new();
+    assert!(templ_path.exists());
+    fs::File::open(&templ_path)?.read_to_string(&mut contents)?;
+    assert_eq!(contents, templ_content);
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_new_from_file_exists() -> Result<(), Box<dyn Error>> {
+    let _t = Test::init("new_from_file_missing", vec![], HashMap::new(), "touch");
+
+    let mut cmd = Command::cargo_bin("templaar")?;
+    cmd.arg("new").arg("-f").arg("templ").arg("templ");
+    cmd.assert().failure();
+
+    Ok(())
+}
+
+#[test]
+#[serial]
 fn test_no_editor() -> Result<(), Box<dyn Error>> {
     env::remove_var("EDITOR");
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -129,8 +129,8 @@ fn test_new_global() -> Result<(), Box<dyn Error>> {
 fn test_new_exists() -> Result<(), Box<dyn Error>> {
     let _t = Test::init(
         "new_exists",
-        vec![PathBuf::from_str(".templ.aar")?],
-        HashMap::new(),
+        vec![],
+        HashMap::from([(PathBuf::from_str(".templ.aar")?, String::new())]),
         "touch",
     );
 
@@ -355,11 +355,11 @@ fn test_take_no_change() -> Result<(), Box<dyn Error>> {
 fn test_take_exists() -> Result<(), Box<dyn Error>> {
     let _t = Test::init(
         "take_exists",
-        vec![
-            PathBuf::from_str(".templ.aar")?,
-            PathBuf::from_str("templ")?,
-        ],
-        HashMap::new(),
+        vec![],
+        HashMap::from([
+            (PathBuf::from_str(".templ.aar")?, String::new()),
+            (PathBuf::from_str("templ")?, String::new()),
+        ]),
         "touch",
     );
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -153,7 +153,7 @@ fn test_new_from_file() -> Result<(), Box<dyn Error>> {
     );
 
     let mut cmd = Command::cargo_bin("templaar")?;
-    cmd.arg("new").arg("-f").arg("templ").arg("templ");
+    cmd.arg("new").arg("templ").arg("-f").arg("templ");
     cmd.assert().success();
 
     let templ_path = Path::new(".templ.aar");
@@ -161,6 +161,47 @@ fn test_new_from_file() -> Result<(), Box<dyn Error>> {
     assert!(templ_path.exists());
     fs::File::open(&templ_path)?.read_to_string(&mut contents)?;
     assert_eq!(contents, templ_content);
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_new_from_multiple_files() -> Result<(), Box<dyn Error>> {
+    let file1_content = "Template";
+    let file2_content = "Other template";
+    let _t = Test::init(
+        "new_from_multiple_files",
+        vec![],
+        HashMap::from([
+            (PathBuf::from_str("file1")?, file1_content.to_string()),
+            (PathBuf::from_str("file2")?, file2_content.to_string()),
+        ]),
+        "touch",
+    );
+
+    let mut cmd = Command::cargo_bin("templaar")?;
+    cmd.arg("new")
+        .arg("templ")
+        .arg("-f")
+        .arg("file1")
+        .arg("file2");
+    cmd.assert().success();
+
+    let templ_path = Path::new(".templ.aar");
+    let file1_path = templ_path.join("file1");
+    let file2_path = templ_path.join("file2");
+    assert!(templ_path.exists());
+    assert!(file1_path.exists());
+    assert!(file2_path.exists());
+
+    let mut contents = String::new();
+    fs::File::open(&file1_path)?.read_to_string(&mut contents)?;
+    assert_eq!(contents, file1_content);
+
+    contents.clear();
+    fs::File::open(&file2_path)?.read_to_string(&mut contents)?;
+    assert_eq!(contents, file2_content);
 
     Ok(())
 }


### PR DESCRIPTION
Allow creating templates from existing files (using `--files` option). When multiple files are specified, a so-called *directory template* is created and all the files are copied there. Then, running `templaar take NAME` on such a template will copy all the files from the template directory into the directory `NAME` (which is created if it doesn't exist).